### PR TITLE
fixed typo "demonstarate" on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # githubify_iitm
 
-## This is a sample repository to demonstarate the practices of forking, issues and pull requests.
+## This is a sample repository to demonstrate the practices of forking, issues and pull requests.
 
 ### To be eligible for submission, fork this repository, work with the assigned issue, add your name below and open a pull request.
 


### PR DESCRIPTION
Merge fixes a typo on README.md. "Demonstarate" should be changed to "demonstrate".